### PR TITLE
IS-2999: Remove veilederident from payload

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsplanEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsplanEndpoints.kt
@@ -13,6 +13,7 @@ import no.nav.syfo.domain.Virksomhetsnummer
 import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.infrastructure.clients.veiledertilgang.validateVeilederAccess
+import no.nav.syfo.util.getNavIdent
 import no.nav.syfo.util.getPersonident
 
 fun Route.registerOppfolgingsplanEndpoints(
@@ -56,7 +57,7 @@ fun Route.registerOppfolgingsplanEndpoints(
                 val result =
                     foresporselService.createForesporsel(
                         arbeidstakerPersonident = Personident(requestDTO.arbeidstakerPersonident),
-                        veilederident = Veilederident(requestDTO.veilederident),
+                        veilederident = Veilederident(call.getNavIdent()),
                         virksomhetsnummer = Virksomhetsnummer(requestDTO.virksomhetsnummer),
                         narmestelederPersonident = Personident(requestDTO.narmestelederPersonident),
                     )

--- a/src/main/kotlin/no/nav/syfo/api/model/ForesporselRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/ForesporselRequestDTO.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.api.model
 
 data class ForesporselRequestDTO(
     val arbeidstakerPersonident: String,
-    val veilederident: String,
     val virksomhetsnummer: String,
     val narmestelederPersonident: String,
 )

--- a/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
@@ -19,7 +19,7 @@ fun ApplicationCall.getConsumerClientId(): String? =
         JWT.decode(it).claims[JWT_CLAIM_AZP]?.asString()
     }
 
-fun ApplicationCall.getNAVIdent(): String {
+fun ApplicationCall.getNavIdent(): String {
     val token = getBearerHeader() ?: throw Error("No Authorization header supplied")
     return JWT.decode(token).claims[JWT_CLAIM_NAVIDENT]?.asString()
         ?: throw Error("Missing NAVident in private claims")

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/OppfolgingsplanEndpointsTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/OppfolgingsplanEndpointsTest.kt
@@ -113,7 +113,6 @@ object OppfolgingsplanEndpointsTest {
             assertEquals(stored.size, 1)
             val storedForesporsel = stored[0]
             assertEquals(storedForesporsel.arbeidstakerPersonident, foresporselRequestDTO.arbeidstakerPersonident)
-            assertEquals(storedForesporsel.veilederident, foresporselRequestDTO.veilederident)
             assertEquals(storedForesporsel.narmestelederPersonident, foresporselRequestDTO.narmestelederPersonident)
             assertEquals(storedForesporsel.virksomhetsnummer, foresporselRequestDTO.virksomhetsnummer)
         }
@@ -146,7 +145,6 @@ object OppfolgingsplanEndpointsTest {
     private fun createForesporselRequestDTO(arbeidstakerPersonident: Personident = ARBEIDSTAKER_PERSONIDENT) =
         ForesporselRequestDTO(
             arbeidstakerPersonident = arbeidstakerPersonident.value,
-            veilederident = VEILEDER_IDENT.value,
             virksomhetsnummer = VIRKSOMHETSNUMMER.value,
             narmestelederPersonident = NARMESTELEDER_FNR.value,
         )


### PR DESCRIPTION
Fjerner `veilederident` fra payload ettersom dette kan utledes fra tokenet. Så slipper vi også å sende inn dette i frontend hvor man starter en forespørsel av oppfølgingsplan for sykmeldt.

Se [PR i frontend](https://github.com/navikt/syfomodiaperson/pull/1604).