### PR TITLE
IS-3006: Publish narmeste leder varsel in crojob

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -83,3 +83,5 @@ spec:
       value: "dev-gcp.teamsykefravr.istilgangskontroll"
     - name: ISTILGANGSKONTROLL_URL
       value: "http://istilgangskontroll"
+    - name: NARMESTELEDER_VARSEL_ENABLED
+      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -83,3 +83,5 @@ spec:
       value: "prod-gcp.teamsykefravr.istilgangskontroll"
     - name: ISTILGANGSKONTROLL_URL
       value: "http://istilgangskontroll"
+    - name: NARMESTELEDER_VARSEL_ENABLED
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -53,6 +53,7 @@ data class Environment(
                 ),
         ),
     val isJournalforingRetryEnabled: Boolean = getEnvVar("JOURNALFORING_RETRY_ENABLED").toBoolean(),
+    val narmestelederVarselEnabled: Boolean = getEnvVar("NARMESTELEDER_VARSEL_ENABLED", "false").toBoolean(),
 )
 
 fun getEnvVar(

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsplanEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsplanEndpoints.kt
@@ -61,11 +61,7 @@ fun Route.registerOppfolgingsplanEndpoints(
                         virksomhetsnummer = Virksomhetsnummer(requestDTO.virksomhetsnummer),
                         narmestelederPersonident = Personident(requestDTO.narmestelederPersonident),
                     )
-
-                result.fold(
-                    onSuccess = { call.respond(HttpStatusCode.Created, ForesporselResponseDTO.fromForesporsel(it)) },
-                    onFailure = { call.respond(HttpStatusCode.InternalServerError, it.toString()) },
-                )
+                call.respond(HttpStatusCode.Created, ForesporselResponseDTO.fromForesporsel(result))
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/application/IForesporselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IForesporselRepository.kt
@@ -14,4 +14,6 @@ interface IForesporselRepository {
     fun setJournalpostId(journalfortForesporsel: Foresporsel)
 
     fun setPublishedAt(foresporselUuid: UUID)
+
+    fun getUnpublishedForesporsler(): List<Foresporsel>
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -21,6 +21,10 @@ fun launchCronjobs(
     cronjobs.add(
         JournalforForesporselCronjob(foresporselService = foresporselService)
     )
+    if (environment.narmestelederVarselEnabled) {
+        val publishNarmestelederVarselCronjob = PublishNarmestelederVarselCronjob(foresporselService = foresporselService)
+        cronjobs.add(publishNarmestelederVarselCronjob)
+    }
 
     cronjobs.forEach {
         launchBackgroundTask(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/PublishNarmestelederVarselCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/PublishNarmestelederVarselCronjob.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import no.nav.syfo.application.ForesporselService
+
+class PublishNarmestelederVarselCronjob(
+    private val foresporselService: ForesporselService,
+) : Cronjob {
+    override val initialDelayMinutes: Long = 5
+    override val intervalDelayMinutes: Long = 10
+
+    override suspend fun run(): List<Result<Any>> = foresporselService.publishedNarmestelederVarsler()
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/ForesporselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/ForesporselRepository.kt
@@ -75,6 +75,14 @@ class ForesporselRepository(val database: DatabaseInterface) : IForesporselRepos
         }
     }
 
+    override fun getUnpublishedForesporsler(): List<Foresporsel> =
+        database.connection.use { connection ->
+            connection.prepareStatement(GET_UNPUBLISHED_FORESPORSEL).use {
+                it.executeQuery()
+                    .toList { toPForesporsel().toForesporsel() }
+            }
+        }
+
     companion object {
         private const val CREATE_FORESPORSEL =
             """
@@ -115,6 +123,14 @@ class ForesporselRepository(val database: DatabaseInterface) : IForesporselRepos
         private const val SET_FORESPORSEL_JOURNALFORING =
             """
                 UPDATE foresporsel SET journalpost_id=? WHERE uuid=?
+            """
+
+        private const val GET_UNPUBLISHED_FORESPORSEL =
+            """
+                SELECT *
+                FROM foresporsel
+                WHERE published_at IS NULL
+                ORDER BY created_at ASC
             """
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/EsyfovarselHendelseProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/EsyfovarselHendelseProducer.kt
@@ -16,9 +16,7 @@ class EsyfovarselHendelseProducer(
                     ESYFOVARSEL_TOPIC,
                     UUID.randomUUID().toString(),
                     NarmesteLederHendelse(
-                        // TODO: Correct varsel type
                         type = HendelseType.NL_OPPFOLGINGSPLAN_FORESPORSEL,
-                        // TODO: Avklar med esyfo hva som trengs her
                         data = null,
                         narmesteLederFnr = foresporsel.narmestelederPersonident.value,
                         arbeidstakerFnr = foresporsel.arbeidstakerPersonident.value,

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -52,6 +52,7 @@ fun testEnvironment() =
             ),
         electorPath = "electorPath",
         isJournalforingRetryEnabled = true,
+        narmestelederVarselEnabled = true,
     )
 
 fun testAppState() =

--- a/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceTest.kt
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test
 import java.util.*
 
 class JournalforingServiceTest {
-    val externalMockEnvironment = ExternalMockEnvironment.instance
-    val dokarkivMock = mockk<DokarkivClient>(relaxed = true)
-    val journalforingService =
+    private val externalMockEnvironment = ExternalMockEnvironment.instance
+    private val dokarkivMock = mockk<DokarkivClient>(relaxed = true)
+    private val journalforingService =
         JournalforingService(
             dokarkivClient = dokarkivMock,
             eregClient = externalMockEnvironment.eregClient,


### PR DESCRIPTION
Publiserer forespørsler om oppfølgingsplan til esyfovarsel slik at det går ut varsel til nærmeste leder. Foreløpig gjøres dette bare i en cronjob.