### PR TITLE
IS-2999: Change from No-Content to OK with empty list response

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsplanEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/OppfolgingsplanEndpoints.kt
@@ -38,11 +38,7 @@ fun Route.registerOppfolgingsplanEndpoints(
                         personident = personident,
                     )
                 val responseDTO = foresporsler.map { ForesporselResponseDTO.fromForesporsel(it) }
-                if (responseDTO.isEmpty()) {
-                    call.respond(HttpStatusCode.NoContent)
-                } else {
-                    call.respond(HttpStatusCode.OK, responseDTO)
-                }
+                call.respond(HttpStatusCode.OK, responseDTO)
             }
         }
 

--- a/src/main/kotlin/no/nav/syfo/api/model/ForesporselResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/ForesporselResponseDTO.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.api.model
 
+import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.Foresporsel
 import java.time.OffsetDateTime
 import java.util.*
@@ -11,6 +12,7 @@ data class ForesporselResponseDTO(
     val veilederident: String,
     val virksomhetsnummer: String,
     val narmestelederPersonident: String,
+    val document: List<DocumentComponent>,
 ) {
     companion object {
         fun fromForesporsel(foresporsel: Foresporsel) =
@@ -21,6 +23,7 @@ data class ForesporselResponseDTO(
                 veilederident = foresporsel.veilederident.value,
                 virksomhetsnummer = foresporsel.virksomhetsnummer.value,
                 narmestelederPersonident = foresporsel.narmestelederPersonident.value,
+                document = foresporsel.document,
             )
     }
 }


### PR DESCRIPTION
- Virker mer riktig å returnere `OK` med tom liste når jeg kikker rundt på nett, og det gjør [oppdatering av innhold i querykeys i queryclient](https://github.com/navikt/syfomodiaperson/pull/1620#discussion_r1935788150) enklere 😊
Noen tanker rundt hvordan vi bør gjøre sånt? 
- Legger også til `document` i responsen når man henter og ber om oppfølgingsplan 
- Se [tilhørende PR](https://github.com/navikt/syfomodiaperson/pull/1620) i `syfomodiaperson`