### PR TITLE
IS-3073: Fix GET foresporsel ordering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/ForesporselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/ForesporselRepository.kt
@@ -109,6 +109,7 @@ class ForesporselRepository(val database: DatabaseInterface) : IForesporselRepos
                 SELECT *
                 FROM foresporsel
                 WHERE arbeidstaker_personident = ?
+                ORDER BY created_at DESC
             """
 
         private const val SET_PUBLISHED_AT =

--- a/src/test/kotlin/no/nav/syfo/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/UserConstants.kt
@@ -10,8 +10,10 @@ object UserConstants {
     val ARBEIDSTAKER_PERSONIDENT_2 = Personident("12345678911")
     val ARBEIDSTAKER_PERSONIDENT_VEILEDER_NO_ACCESS = Personident("11111111111")
     val VIRKSOMHETSNUMMER = Virksomhetsnummer("981111117")
+    val OTHER_VIRKSOMHETSNUMMER = Virksomhetsnummer("981111127")
     val VIRKSOMHETSNAVN = "Bedriften"
     val NARMESTELEDER_FNR = Personident("98765432101")
+    val OTHER_NARMESTELEDER_FNR = Personident("98765432102")
     val VEILEDER_IDENT = Veilederident("Z999999")
 
     const val VIRKSOMHETSNUMMER_2 = "123456781"


### PR DESCRIPTION
Oppdaget under testing at nyeste foresporsel ikke lå først i lista fra GET-endepunktet. Fikset sortering slik vi gjør i andre apper siden frontend baserer seg på det.